### PR TITLE
PLANET-3307 Remove workspace attachment in prepare-release job

### DIFF
--- a/config-jw-template.yml
+++ b/config-jw-template.yml
@@ -36,18 +36,11 @@ job_definitions:
     working_directory: /tmp/workspace/src
     steps:
       - checkout
-      - attach_workspace:
-          at: /tmp/workspace
       - run: release-prepare-nro.sh
       - run:
           name: Notify failure
           when: on_fail
           command: TYPE="Prepare" notify-job-failure.sh
-      - persist_to_workspace:
-          root: /tmp/workspace
-          paths:
-            - var
-            - src
 
   notify_promote: &notify_promote
     working_directory: ~/project


### PR DESCRIPTION
Since prepare release job seems independent from the rest of the workflow jobs
- Remove workspace attachment from prepare-release job
- Remove workspace persistance since it is the last job in the workflow

This allows git flow release to run on clean checked out repo so that merged repos (base-fork NRO) from previous job won't interfere with the process.

Fix changes done in this [PR](https://github.com/greenpeace/planet4-builder/pull/17/files) that ended up commiting base-fork's files in NROs repos